### PR TITLE
NOJIRA Reducing data retention time to prevent disk quota errors.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -5,4 +5,4 @@ applications:
     buildpacks:
       - binary_buildpack
     stack: cflinuxfs3
-    command: ./prometheus --config.file=prometheus.yml --web.listen-address=:8080
+    command: ./prometheus --config.file=prometheus.yml --web.listen-address=:8080 --storage.tsdb.retention.time='1d'


### PR DESCRIPTION
- Reducing log retention time from the default time of 15 days to one day to prevent errors cause from disk quota issues.
- The logs are written remotely to a hosted prometheus instance so we don't care about the metrics that are stored locally.